### PR TITLE
Add approach to mock requests to microsoft api

### DIFF
--- a/microsoft_test.go
+++ b/microsoft_test.go
@@ -1,0 +1,36 @@
+package microsoft
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func makeServer(code int, body string) (*httptest.Server, *http.Client) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, body)
+	}))
+	defer server.Close()
+
+	transport := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(server.URL)
+		},
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	return server, httpClient
+}
+
+func TestGetToken(t *testing.T) {
+
+	_, mockClient := makeServer(200, `{"token_id": "token_mock_id", "expires_in": "600"}`)
+
+	authReq := AuthRequest{ClientId: "translate1", ClientSecret: "translates3cr3t", HTTPClient: mockClient}
+	resp := authReq.GetAccessToken()
+	t.Logf("%#v\n", resp)
+}


### PR DESCRIPTION
This change in the package code `microsoft` allows you to fake requests to be used in testing, but for now, is in trouble.

```
2015/07/22 08:45:12 Post https://datamarket.accesscontrol.windows.net/v2/OAuth2-13: http: error connecting to proxy https://127.0.0.1:61522: dial tcp 127.0.0.1:61522:
 connection refused
--- FAIL: TestGetToken (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x61d05]

```
